### PR TITLE
fix: remove tab indentation in SimpleTransfer.sol

### DIFF
--- a/contracts/simple_transfer/ethereum/SimpleTransfer.sol
+++ b/contracts/simple_transfer/ethereum/SimpleTransfer.sol
@@ -17,7 +17,7 @@ contract SimpleTransfer{
 
     function withdraw(uint256 amount) public {
         require(msg.sender == recipient, "only the recipient can withdraw");
-	require(amount <= address(this).balance, "the contract balance is less then required amount");
+        require(amount <= address(this).balance, "the contract balance is less then required amount");
 
         (bool success, ) = recipient.call{value: amount}("");
         require(success, "Transfer failed.");


### PR DESCRIPTION
This PR simply replaces the remaining tab indentation in the SimpleTransfer.sol contract with space indentation, so to keep the indentation style consistent across the contract code.