### PR TITLE
Fix deadline condition in auction contract

### DIFF
--- a/contracts/auction/ethereum/vyper/Auction.vy
+++ b/contracts/auction/ethereum/vyper/Auction.vy
@@ -4,7 +4,7 @@ MAX_OBJECT_NAME: constant(uint256) = 64
 seller: public(address)
 highestBid: public(uint256)
 startingBid: public(uint256)
-duration: public(uint256)   # Duration in seconds
+duration: public(uint256)   # Duration in blocks
 deadline: public(uint256)   # Time when auction ends 
 objectName: public(String[64])
 auctionStarted: public(bool)
@@ -29,7 +29,7 @@ def start():
     assert not self.auctionStarted, "Auction already started"
 
     self.auctionStarted = True
-    self.deadline = block.timestamp + self.duration
+    self.deadline = block.number + self.duration
 
 
 @payable
@@ -37,7 +37,7 @@ def start():
 def bid():
     assert self.auctionStarted, "Auction not started yet"
     assert not self.auctionEnded, "Auction ended"
-    assert self.deadline > block.timestamp, "Bidding time expired"
+    assert block.number < self.deadline, "Bidding time expired"
     assert msg.sender != self.highestBidder, "Already highest bidder"
     assert msg.value > self.highestBid, "Amount is lower than the highest bid"
     assert msg.sender != self.seller, "Seller cannot bid"
@@ -73,7 +73,7 @@ def end():
     assert self.auctionStarted, "Auction not started"
     assert not self.auctionEnded, "Auction already ended"
     assert msg.sender == self.seller, "Only the seller"
-    assert self.deadline < block.timestamp, "Bids are still open"
+    assert block.number >= self.deadline, "Bids are still open"
     self.auctionEnded = True 
 
     # Send the highest bid to seller 

--- a/contracts/auction/ethereum/vyper/README.md
+++ b/contracts/auction/ethereum/vyper/README.md
@@ -6,7 +6,7 @@
 seller: public(address)
 highestBid: public(uint256)
 startingBid: public(uint256)
-duration: public(uint256)   # Duration in seconds
+duration: public(uint256)   # Duration in blocks
 deadline: public(uint256)   # Time when auction ends 
 objectName: public(String[MAX_OBJECT_NAME])
 auctionStarted: public(bool)
@@ -48,14 +48,14 @@ def start():
     assert not self.auctionStarted, "Auction already started"
 
     self.auctionStarted = True
-    self.deadline = block.timestamp + self.duration
+    self.deadline = block.number + self.duration
 ```
 
 This function starts the auction. It performs the following checks and actions:
 - Verifies that the caller is the seller (only the seller can start the auction).
 - Ensures the auction has not already started.
 - Sets the auctionStarted flag to True.
-- Calculates and stores the bidding deadline based on the current block timestamp and auction duration.
+- Calculates and stores the bidding deadline based on the current block number and auction duration.
 
 ## bid
 
@@ -65,7 +65,7 @@ This function starts the auction. It performs the following checks and actions:
 def bid():
     assert self.auctionStarted, "Auction not started yet"
     assert not self.auctionEnded, "Auction ended"
-    assert self.deadline > block.timestamp, "Bidding time expired"
+    assert block.number > self.deadline, "Bidding time expired"
     assert msg.sender != self.highestBidder, "Already highest bidder"
     assert msg.value > self.highestBid, "Amount is lower than the highest bid"
     assert msg.sender != self.seller, "Seller cannot bid"
@@ -136,7 +136,7 @@ def end():
     assert self.auctionStarted, "Auction not started"
     assert not self.auctionEnded, "Auction already ended"
     assert msg.sender == self.seller, "Only the seller"
-    assert self.deadline < block.timestamp, "Bids are still open"
+    assert block.number < self.deadline, "Bids are still open"
     self.auctionEnded = True 
 
     # Send the highest bid to seller 


### PR DESCRIPTION
Changed from using block.timestamp to block.number to compute the deadline and associated checks